### PR TITLE
fix: todo編集機能を実装

### DIFF
--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -2,32 +2,63 @@
 import { ref } from 'vue'
 import type { Ref } from 'vue';
 
-const todos: Ref<string[]> = ref(['Shopping', 'Rent Pay', 'Cleaning']) // todoリスト配列。型を追加
-const newTodo: Ref<string> = ref('')// 追加する新たなtodo
+const input = ref() // フォーカスしたいinputを割り当てるための変数。TODO:型
 
-function addTodo(): void{ // todoを追加。追加ボタンをバインド
-    todos.value.push(newTodo.value)
+type Todo = { // todoオブジェクトの型
+    text: string;
+    isEditing: boolean;
+};
+
+const todos: Ref<Todo[]> = ref([ // todoリスト配列
+    {text: 'Shopping', isEditing: false},
+    {text: 'Rent Pay', isEditing: false},
+    {text: 'Cleaning', isEditing: false}
+])
+
+const newTodo: Ref<Todo> = ref({text: '', isEditing: false}) // 追加する新たなtodo
+
+function addTodo(){ // todoを追加。追加ボタンをバインド
+    if(newTodo.value.text != ''){ // TODO:バリデーション再考の余地
+         /**
+          * newTodo.valueを直接pushすると、追加したtodoに入力フォームのvalueが
+          * 同期されてしまうので、スプレッド演算子でコピー
+          */
+        todos.value.push({ ...newTodo.value })
+        newTodo.value.text = '' // 不要なので入力をクリア
+    }
+    input.value.focus()
 }
 
-function deleteTodo(index: number): void{ // todoを削除。削除ボタンをバインド
+function editTodo(index: number){ // todoを編集。編集ボタンにバインド
+    todos.value[index].isEditing = true
+}
+
+function updateTodo(index: number){ // todoを更新。完了ボタンにバインド
+    todos.value[index].isEditing = false
+}
+
+function deleteTodo(index: number){ // todoを削除。削除ボタンをバインド
     todos.value.splice(index, 1)
 }
 </script>
 
 <template>
     <h1>TODO LIST</h1>
-    <input v-model="newTodo" placeholder="TODOを入力" /> <!--入力内容をnewTodoと同期-->
+    <input v-model="newTodo.text" ref="input" placeholder="TODOを入力" /> <!--入力内容をnewTodoと同期-->
     <button @click="addTodo">追加</button> <!--新しいtodoの追加-->
 
     <h2>LIST OF WORKS TODO:</h2>
-    <ul id="todo-list"> <!--todoリスト-->
-        <li v-for="(todo, index) in todos" :key="index">
-            {{ todo }}
-            <button>編集</button> <!--現時点ではボタンは機能しません-->
+    <ul v-for="(todo, index) in todos" :key="index" id="todo-list"> <!--todoリスト-->
+        <li v-if="!todo.isEditing"> <!--初期状態、または、完了ボタンが押されisEditing:falseとなったとき表示-->
+            {{ todo.text }}
+            <button @click="editTodo(index)">編集</button>
             <button @click="deleteTodo(index)">削除</button>
         </li>
+        <li v-else> <!--編集ボタンが押されisEditing:trueとなったとき表示-->
+            <input v-model="todo.text" placeholder="TODOを入力" />
+            <button @click="updateTodo(index)">完了</button>
+        </li>
     </ul>
-
 </template>
 
 <style>


### PR DESCRIPTION
- todo編集機能を実装しました。
  - 各todoに当てた真偽値を、「編集」または「完了」ボタンによって切り替え、真偽それぞれに紐づく一覧・編集画面を表示させることで実現しました。
  - 真偽値を持たせるため、todoをオブジェクト型に変更しました。

- todo追加を実行した際、入力フォームにフォーカスが当たるようにしました。
  - 関心事が2つになってしまい申し訳ありません。以後改善します。
  - フォーカスしたい要素をref=でref()に割り当て、focus()でフォーカスを当てました。

- 微調整として、todo追加の際にnewTodo.valueを直接pushすると、追加したtodoに入力フォームのvalueが同期されてしまうので、スプレッド演算子でコピーしました。




https://github.com/user-attachments/assets/1a93710b-1491-463b-9afb-ce83b2fd16c4

