### PR TITLE
fix: ダムコンポーネントを意識し修正・addしたときのフォーカスを修正

### DIFF
--- a/src/components/TodoForm.vue
+++ b/src/components/TodoForm.vue
@@ -4,21 +4,20 @@ import { useTodoStore } from '../stores/todoStore.ts'
 
 const todo = useTodoStore()
 const input = ref() // フォーカスしたいinputを割り当てるための変数。TODO:型
-const newTodo = ref<string>('') // 追加する新たなtodo
+const newTodoText = ref('') // 追加する新たなtodo
 const addTodo = todo.addTodo
 
 function addTodoAndFocus(newTodo: string) {
     addTodo(newTodo)
-    input.value = '' // 不要なので入力をクリア
     input.value.focus()
-
+    newTodoText.value = '' // 不要なので入力をクリア
 }
 </script>
 
 <template>
     <h1>TODO LIST</h1>
-    <input v-model="newTodo" ref="input" placeholder="TODOを入力" /> <!--入力内容をnewTodoと同期-->
-    <button @click="addTodoAndFocus(newTodo)">追加</button> <!--新しいtodoの追加-->
+    <input v-model="newTodoText" ref="input" placeholder="TODOを入力" /> <!--入力内容をnewTodoと同期-->
+    <button @click="addTodoAndFocus(newTodoText)">追加</button> <!--新しいtodoの追加-->
 </template>
 
 <style>

--- a/src/components/TodoForm.vue
+++ b/src/components/TodoForm.vue
@@ -9,7 +9,7 @@ const addTodo = todo.addTodo
 
 function addTodoAndFocus(newTodo: string) {
     addTodo(newTodo)
-    newTodo = '' // 不要なので入力をクリア
+    input.value = '' // 不要なので入力をクリア
     input.value.focus()
 
 }

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useTodoStore } from '../stores/todoStore.ts'
+
+const todo = useTodoStore()
+
+const props = defineProps<{
+    todoText: string
+    index: number
+}>()
+
+const userInput = ref(props.todoText)
+const isEditing = ref(false)
+
+function editTodo() { // todoを編集。編集ボタンにバインド
+    isEditing.value = true
+}
+
+function completeEditTodo(index: number, userInput: string) { // todoを更新して通常画面に戻す。完了ボタンにバインド
+    todo.updateTodo(index, userInput)
+    isEditing.value = false
+}
+</script>
+
+<template>
+    <li v-if="isEditing">
+        <input v-model="userInput" placeholder="TODOを入力" />
+        <button @click="completeEditTodo(index, userInput)">完了</button>
+    </li>
+    <li v-else>
+        {{ todoText }}
+        <button @click="editTodo">編集</button>
+        <button @click="todo.deleteTodo(index)">削除</button>
+    </li>
+</template>
+
+<style>
+
+</style>

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -1,26 +1,20 @@
 <script setup lang="ts">
 import { useTodoStore } from '../stores/todoStore.ts'
+import TodoItem from './TodoItem.vue'
 
 const todo = useTodoStore()
 const todos = todo.todos
-const editTodo = todo.editTodo
-const updateTodo = todo.updateTodo
-const deleteTodo = todo.deleteTodo
 </script>
 
 <template>
     <h2>LIST OF WORKS TODO:</h2>
-    <ul v-for="(todo, index) in todos" :key="index" id="todo-list"> <!--todoリスト-->
-        <li v-if="!todo.isEditing"> <!--初期状態、または、完了ボタンが押されisEditing:falseとなったとき表示-->
-            {{ todo.text }}
-            <button @click="editTodo(index)">編集</button>
-            <button @click="deleteTodo(index)">削除</button>
-        </li>
-        <li v-else> <!--編集ボタンが押されisEditing:trueとなったとき表示-->
-            <input v-model="todo.text" placeholder="TODOを入力" />
-            <button @click="updateTodo(index)">完了</button>
-        </li>
-    </ul>
+    <TodoItem
+        v-for="(todo, index) in todos"
+        :key="index"
+        :todoText="todo"
+        :index="index"
+        id="todo-list"
+    />
 </template>
 
 <style>

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -1,42 +1,24 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue'
 
-export type Todo = { // todoオブジェクトの型
-    text: string;
-    isEditing: boolean;
-}
-
 export const useTodoStore = defineStore('todo', () => {
 
-    const todos = ref<Todo[]>([ // todoリスト配列
-        {text: 'Shopping', isEditing: false},
-        {text: 'Rent Pay', isEditing: false},
-        {text: 'Cleaning', isEditing: false}
-    ])
+    const todos = ref(['Shopping', 'Rent Pay', 'Cleaning']) // todoリスト配列
 
     function addTodo(newTodo: string) { // todoを追加。追加ボタンをバインド
-        if(newTodo != '') { // TODO:バリデーション再考の余地
-             /**
-              * newTodo.valueを直接pushすると、追加したtodoに入力フォームのvalueが
-              * 同期されてしまうので、スプレッド演算子でコピー
-              */
-            todos.value.push({ text: newTodo, isEditing: false })
-        }
+        if (newTodo === '') return // TODO:バリデーション再考の余地
+        todos.value.push(newTodo)
     }
-    
-    function editTodo(index: number) { // todoを編集。編集ボタンにバインド
-        todos.value[index].isEditing = true
+
+    function updateTodo(index: number, userInput: string) { // todoを更新
+        todos.value[index] = userInput
     }
-    
-    function updateTodo(index: number) { // todoを更新。完了ボタンにバインド
-        todos.value[index].isEditing = false
-    }
-    
+
     function deleteTodo(index: number) { // todoを削除。削除ボタンをバインド
         todos.value.splice(index, 1)
     }
 
-    return { todos, addTodo, editTodo, updateTodo, deleteTodo }
+    return { todos, addTodo, updateTodo, deleteTodo }
 })
 
 


### PR DESCRIPTION
- ダムコンポーネントを意識し修正
  - todo1つ1つをTodoItemとして切り出し、ダムコンポーネントにしました
  - isEditingをTodoItemに持たせました
- addしたときのフォーカスを修正→ではなくaddしたときの入力欄のクリアでした


https://github.com/user-attachments/assets/03c3688a-fe4e-4a21-a335-32c42139631b

