### PR TITLE
fix: todoの完了をline-throughで表現・text-decorationを、インラインスタイルではなくクラスを用いて適用

### DIFF
--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -27,10 +27,10 @@ function completeEditTodo(index: number, userInput: string) { // todoを更新�
         <input v-model="userInput" placeholder="TODOを入力" />
         <button @click="completeEditTodo(index, userInput)">完了</button>
     </li>
-    <li v-else>
+    <li v-else :style="{ textDecoration: todo.todos[index].isCompleted ? 'line-through' : 'none' }">
         {{ todoText }}
         <button @click="editTodo">編集</button>
-        <button @click="todo.deleteTodo(index)">削除</button>
+        <button @click="todo.toggleTodo(index)">済</button>
     </li>
 </template>
 

--- a/src/components/TodoItem.vue
+++ b/src/components/TodoItem.vue
@@ -6,6 +6,7 @@ const todo = useTodoStore()
 
 const props = defineProps<{
     todoText: string
+    isCompleted: boolean
     index: number
 }>()
 
@@ -27,7 +28,7 @@ function completeEditTodo(index: number, userInput: string) { // todoを更新�
         <input v-model="userInput" placeholder="TODOを入力" />
         <button @click="completeEditTodo(index, userInput)">完了</button>
     </li>
-    <li v-else :style="{ textDecoration: todo.todos[index].isCompleted ? 'line-through' : 'none' }">
+    <li v-else :class="{ 'text-decoration': isCompleted }">
         {{ todoText }}
         <button @click="editTodo">編集</button>
         <button @click="todo.toggleTodo(index)">済</button>
@@ -35,5 +36,7 @@ function completeEditTodo(index: number, userInput: string) { // todoを更新�
 </template>
 
 <style>
-
+.text-decoration {
+    text-decoration: line-through;
+}
 </style>

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -12,6 +12,7 @@ const todos = todo.todos
         v-for="(todo, index) in todos"
         :key="index"
         :todoText="todo.text"
+        :isCompleted="todo.isCompleted"
         :index="index"
         id="todo-list"
     />

--- a/src/components/TodoList.vue
+++ b/src/components/TodoList.vue
@@ -11,7 +11,7 @@ const todos = todo.todos
     <TodoItem
         v-for="(todo, index) in todos"
         :key="index"
-        :todoText="todo"
+        :todoText="todo.text"
         :index="index"
         id="todo-list"
     />

--- a/src/stores/todoStore.ts
+++ b/src/stores/todoStore.ts
@@ -1,24 +1,33 @@
 import { defineStore } from 'pinia';
 import { ref } from 'vue'
 
+export type Todo= {
+    text: string;
+    isCompleted: boolean;
+};
+
 export const useTodoStore = defineStore('todo', () => {
 
-    const todos = ref(['Shopping', 'Rent Pay', 'Cleaning']) // todoリスト配列
+    const todos = ref([
+        { text: 'Shopping', isCompleted: false },
+        { text: 'Rent Pay', isCompleted: false },
+        { text: 'Cleaning', isCompleted: false }
+    ]) // todoリスト配列
 
     function addTodo(newTodo: string) { // todoを追加。追加ボタンをバインド
         if (newTodo === '') return // TODO:バリデーション再考の余地
-        todos.value.push(newTodo)
+        todos.value.push({text: newTodo, isCompleted: false})
     }
 
     function updateTodo(index: number, userInput: string) { // todoを更新
-        todos.value[index] = userInput
+        todos.value[index].text = userInput
     }
 
-    function deleteTodo(index: number) { // todoを削除。削除ボタンをバインド
-        todos.value.splice(index, 1)
+    function toggleTodo(index: number) { // todoを削除。済ボタンをバインド
+        todos.value[index].isCompleted = !todos.value[index].isCompleted
     }
 
-    return { todos, addTodo, updateTodo, deleteTodo }
+    return { todos, addTodo, updateTodo, toggleTodo }
 })
 
 


### PR DESCRIPTION
- todoの完了をline-throughで表現しました
  - todoにisCompletedプロパティを持たせ、削除ボタンでその真偽値と、それに伴うtext-decorationの適用を切り替えました
- text-decorationを、インラインスタイルではなくクラスを用いて適用しました


https://github.com/user-attachments/assets/dde4018e-b5b5-4786-b303-f2103e3283fe

